### PR TITLE
Fix runner.ts shebang to correctly pass options

### DIFF
--- a/runner.ts
+++ b/runner.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env -S node --no-warnings
 
 import glob from 'glob';
 import { spawn } from 'child_process';


### PR DESCRIPTION
Not sure when it's valid to include more than 1 argument in a shebang. The `-S` option here causes env to split the argument to have the desired effect. See <https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html>.

Without this fix, we see:

```
/usr/bin/env: node --no-warnings: No such file or directory
```